### PR TITLE
feat(构造函数中增加init，判断初始化是否成功): ✨

### DIFF
--- a/example/koa-demo/index.js
+++ b/example/koa-demo/index.js
@@ -1,4 +1,4 @@
-const { CtripApolloClient, withValue } = require('../../src/index')
+const { CtripApolloClient } = require('../../src/index')
 const Koa = require('koa')
 const app = new Koa()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lvgithub/ctrip-apollo-client",
-    "version": "1.0.29",
+    "version": "1.0.30",
     "description": "携程配置中心 Apollo 客户端Node.js版本",
     "main": "src/index.js",
     "types": "./typings/ctripApolloClient.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,11 @@ class Client {
             this.clientIp = clientIp
         })
 
+        this.readyPromise = new Promise((resolve, reject) => {
+          this.resolve = resolve;
+          this.reject = reject;
+        })
+
         // 实现long http polling
         // 递归害怕长时间运行有爆栈的危险
         // this.polling = async () => {
@@ -76,6 +81,8 @@ class Client {
         }, 1)
 
         global._apollo = this
+
+        this.init()
     }
 
     async refreshServerUrl () {
@@ -249,6 +256,10 @@ class Client {
         return configObj
     }
 
+    ready() {
+      return this.readyPromise;
+    }
+
     // 拉取所有配置到本地
     async init (initTimeoutMs) {
         try {
@@ -259,9 +270,11 @@ class Client {
                 this.fetchConfigFromDb(),
                 reject(initTimeoutMs || this.initTimeoutMs)
             ])
+            this.resolve();
         } catch (error) {
             // 初始化失败，恢复本地配置文件
             this.error('error', error)
+            this.reject(error)
             this.apolloConfig = this.readConfigsFromFile()
         }
     }

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -5,6 +5,7 @@ const client = new CtripApolloClient({
     accessKey: '35be8a4868c748ec96faef3e326adad5',
     configPath: './config/apolloConfig.json'
 })
+
 test('test getValue,getConfigs', () => {
     const config = {
         application: {
@@ -52,6 +53,32 @@ test('test readConfigsFromFile', async () => {
     // console.log('config', JSON.stringify(client.apolloConfig))
 
     expect(config).toEqual(client.apolloConfig)
+})
+
+test('test apollo ready ok', async () => {
+  const client = new CtripApolloClient({
+    metaServerUrl: 'http://106.54.227.205:8080',
+    appId: 'apolloclient',
+    accessKey: '35be8a4868c748ec96faef3e326adad5',
+    configPath: './config/apolloConfig.json',
+    initTimeoutMs: 1000
+  });
+
+  const res  = await client.ready();
+  expect(res).toBeUndefined()
+})
+
+test('test apollo ready failed', async () => {
+  const client = new CtripApolloClient({
+    metaServerUrl: 'http://106.54.227.2:8080',
+    appId: 'apolloclient',
+    accessKey: '35be8a4868c748ec96faef3e326adad5',
+    configPath: './config/apolloConfig.json',
+    initTimeoutMs: 1000
+  });
+
+  const err = await client.ready().catch((err) => err)
+  expect(err instanceof Error).toBeTruthy()
 })
 
 // test('test static value', () => {


### PR DESCRIPTION
增加 ready 函数，来判断初始化过程是否成功，从而提前发现因为apollo配置文件错误，apollo连接不上等问题